### PR TITLE
Accept Items as IList instead of List

### DIFF
--- a/Plk.Blazor.DragDrop/DragDropService.cs
+++ b/Plk.Blazor.DragDrop/DragDropService.cs
@@ -12,6 +12,6 @@ namespace Plk.Blazor.DragDrop
     internal class DragDropService<T>
     {
         public T ActiveItem { get; set; }
-        public List<T> Items { get; set; }
+        public IList<T> Items { get; set; }
     }
 }

--- a/Plk.Blazor.DragDrop/Dropzone.razor
+++ b/Plk.Blazor.DragDrop/Dropzone.razor
@@ -163,7 +163,7 @@
     /// <summary>
     /// List of items for the dropzone
     /// </summary>
-    [Parameter] public List<TItem> Items { get; set; }
+    [Parameter] public IList<TItem> Items { get; set; }
 
     /// <summary>
     /// Maximum Number of items which can be dropped in this dropzone. Defaults to null which means unlimited.


### PR DESCRIPTION
This leaves the user more flexible into the type of structure they pass in