### PR TITLE
CopyItem calls when drop to the same dropzone

### DIFF
--- a/Plk.Blazor.DragDrop.Demo/Pages/TwoZones.razor
+++ b/Plk.Blazor.DragDrop.Demo/Pages/TwoZones.razor
@@ -2,7 +2,7 @@
 @using Plk.Blazor.DragDrop.Demo.Components
 @using Plk.Blazor.DragDrop.Demo.Data
 
-<div class="bg-success">You can drag items from one dropzone to another dropzone.</div>
+<div class="bg-success">You can drag items with name "Item 1" from one dropzone to another dropzone.</div>
 
 <hr />
 
@@ -28,7 +28,7 @@
 
 <div class="bg-light">Third Dropzone (copy items):</div>
 
-<Dropzone CopyItem="(item)=> { return new TodoItem() {Titel = item.Titel}; }" Items="MyThirdList" TItem="TodoItem" OnItemDrop="@((i)=>lastdropped = i)">
+<Dropzone CopyItem="(item)=> { return new TodoItem() {Titel = item.Titel }; }" Items="MyThirdList" TItem="TodoItem" OnItemDrop="@((i)=>lastdropped = i)">
     <div style="border: 2px solid black">
         @context.Titel
     </div>

--- a/Plk.Blazor.DragDrop/Dropzone.razor
+++ b/Plk.Blazor.DragDrop/Dropzone.razor
@@ -49,6 +49,7 @@
 
         var activeItem = DragDropService.ActiveItem;
         var oldIndex = Items.IndexOf(activeItem);
+        var sameDropZone = false;
 
         if(oldIndex == -1) // item not present in target dropzone
         {
@@ -59,6 +60,7 @@
         }
         else // same dropzone drop
         {
+            sameDropZone = true;
             Items.RemoveAt(oldIndex);
             // the actual index could have shifted due to the removal
             if (newIndex > oldIndex) newIndex--;
@@ -70,7 +72,8 @@
         }
         else
         {
-            Items.Insert(newIndex, CopyItem(activeItem));
+            // for the same zone - do not call CopyItem
+            Items.Insert(newIndex, sameDropZone ? activeItem : CopyItem(activeItem));
         }
 
         //Operation is finished
@@ -389,10 +392,32 @@
         }
         else // we have a direct target
         {
-            if (!InstantReplace)
+            if( !Items.Contains( activeItem ) ) // if dragged to another dropzone
             {
-                Swap(DragDropService.DragTargetItem, activeItem); //swap target with active item
+                if( CopyItem == null )
+                {
+                    if( !InstantReplace )
+                    {
+                        Swap(DragDropService.DragTargetItem, activeItem); //swap target with active item
+                    }
+                }
+                else
+                {
+                    if( !InstantReplace )
+                    {
+                        Swap(DragDropService.DragTargetItem, CopyItem( activeItem ) ); //swap target with a copy of active item
+                    }
+                }
             }
+            else
+            {
+                // if dragged to the same dropzone
+                if (!InstantReplace)
+                {
+                    Swap( DragDropService.DragTargetItem, activeItem ); //swap target with active item
+                }
+            }
+
         }
 
         DragDropService.Reset();


### PR DESCRIPTION
1. Updated logic to call CopyItem only if drop to another dropzone. Update for both spacer and other item
2. Update help text for Demo 2 to indicate that item with specific title can be dragged only