### PR TITLE
Add CopyItem logic to Swap method

### DIFF
--- a/Plk.Blazor.DragDrop/Dropzone.razor
+++ b/Plk.Blazor.DragDrop/Dropzone.razor
@@ -415,10 +415,18 @@
 
         if (indexActiveItem == -1) // item is new to the dropzone
         {
-            //insert into new zone
-            Items.Insert(indexDraggedOverItem + 1, activeItem);
-            //remove from old zone
-            DragDropService.Items.Remove(activeItem);
+            if (CopyItem == null)
+            {
+                //insert into new zone
+                Items.Insert(indexDraggedOverItem + 1, activeItem);
+                //remove from old zone
+                DragDropService.Items.Remove(activeItem);
+            }
+            else
+            {
+                Items.Insert(indexDraggedOverItem + 1, CopyItem(activeItem)); //insert item to new zone
+            }
+
         }
         else if (InstantReplace) //swap the items
         {


### PR DESCRIPTION
Added logic to check for the CopyItem method when dropping onto an existing item from a different zone.  I feel like this would be desired behavior.  I only added this check when the item being dragged is from a different zone.  