### PR TITLE
Issue with structs in no direct drag target condition

### DIFF
--- a/Plk.Blazor.DragDrop/Dropzone.razor.cs
+++ b/Plk.Blazor.DragDrop/Dropzone.razor.cs
@@ -342,7 +342,7 @@ public partial class Dropzone<TItem>
         }
 
         var activeItem = DragDropService.ActiveItem;
-        if (DragDropService.DragTargetItem == null) //no direct drag target
+        if (EqualityComparer<TItem>.Default.Equals(DragDropService.DragTargetItem, default)) //no direct drag target
         {
             if (!Items.Contains(activeItem)) //if dragged to another dropzone
             {


### PR DESCRIPTION
Comparing here to null can work only if the TItem is class.
If we have structs, for example, KeyValuePair<T1, T2> as a TItem constraint, this condition will fail.
Using default equality comparer here solves the problem, but another issue would be if the default value exists.

For example, if the values in the list are:

- 0
- 1
- 2

having 0 as the target here would reject the drop.

Therefore I am opening this PR to discuss on the proper solution for this case.