### PR TITLE
Remove ShouldRender logic

### DIFF
--- a/Plk.Blazor.DragDrop/DragDropService.cs
+++ b/Plk.Blazor.DragDrop/DragDropService.cs
@@ -30,17 +30,9 @@ internal class DragDropService<T>
     /// </summary>
     public void Reset()
     {
-        ShouldRender = true;
         ActiveItem = default;
         ActiveSpacerId = null;
         Items = null;
         DragTargetItem = default;
-
-        StateHasChanged?.Invoke(this, EventArgs.Empty);
     }
-
-    public bool ShouldRender { get; set; } = true;
-
-    // Notify subscribers that there is a need for rerender
-    public EventHandler StateHasChanged { get; set; }
 }

--- a/Plk.Blazor.DragDrop/Dropzone.razor
+++ b/Plk.Blazor.DragDrop/Dropzone.razor
@@ -1,7 +1,6 @@
 @typeparam TItem
 @inject DragDropService<TItem> DragDropService
 @using System.Text
-@implements IDisposable
 
 <div id="@Id" class="@GetClassesForDropzone()" @ondragover:preventDefault @ondragover="()=> { }" @ondragenter:preventDefault @ondragenter="()=> { }" @ondrop="()=>OnDrop()" @ondrop:preventDefault ondragstart="event.dataTransfer.setData('text', event.target.id);"
      @ondrop:stopPropagation

--- a/Plk.Blazor.DragDrop/Dropzone.razor.cs
+++ b/Plk.Blazor.DragDrop/Dropzone.razor.cs
@@ -73,23 +73,6 @@ public partial class Dropzone<TItem>
     {
         return DragDropService.ActiveItem != null;
     }
-
-    protected override bool ShouldRender()
-    {
-        return DragDropService.ShouldRender;
-    }
-
-    private void ForceRender(object sender, EventArgs e)
-    {
-        StateHasChanged();
-    }
-
-    protected override void OnInitialized()
-    {
-        DragDropService.StateHasChanged += ForceRender;
-        base.OnInitialized();
-    }
-
     public string CheckIfDraggable(TItem item)
     {
         if (AllowsDrag == null)
@@ -134,27 +117,17 @@ public partial class Dropzone<TItem>
         {
             Swap(DragDropService.DragTargetItem, activeItem);
         }
-
-        DragDropService.ShouldRender = true;
-        StateHasChanged();
-        DragDropService.ShouldRender = false;
     }
 
     public void OnDragLeave()
     {
         DragDropService.DragTargetItem = default;
-        DragDropService.ShouldRender = true;
-        StateHasChanged();
-        DragDropService.ShouldRender = false;
     }
 
     public void OnDragStart(TItem item)
     {
-        DragDropService.ShouldRender = true;
         DragDropService.ActiveItem = item;
         DragDropService.Items = Items;
-        StateHasChanged();
-        DragDropService.ShouldRender = false;
     }
 
     public string CheckIfItemIsInTransit(TItem item)
@@ -334,7 +307,6 @@ public partial class Dropzone<TItem>
 
     private void OnDrop()
     {
-        DragDropService.ShouldRender = true;
         if (!IsDropAllowed())
         {
             DragDropService.Reset();
@@ -391,7 +363,6 @@ public partial class Dropzone<TItem>
         }
 
         DragDropService.Reset();
-        StateHasChanged();
         OnItemDrop.InvokeAsync(activeItem);
     }
 
@@ -423,10 +394,5 @@ public partial class Dropzone<TItem>
             Items.RemoveAt(indexActiveItem);
             Items.Insert(indexDraggedOverItem, tmp);
         }
-    }
-
-    public void Dispose()
-    {
-        DragDropService.StateHasChanged -= ForceRender;
     }
 }


### PR DESCRIPTION
This fixes #158.

As your component is using EventCallbacks there is no need to subscribe to an event to manually tell the UI to refresh itself. Blazor will handle this completely automatically. 

The removal of the event lets us also remove the need of IDisposable.

Every example is working fine and all tests have passed. 

